### PR TITLE
Dev: replace unnecessary fatal error with throwing DecodingError

### DIFF
--- a/Sources/AnyCodable.swift
+++ b/Sources/AnyCodable.swift
@@ -139,7 +139,8 @@ public struct AnyCodable: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let typeName = try container.decode(String.self, forKey: .typeName)
         guard let closure = AnyCodable.decodableClosures[typeName] else {
-            fatalError("Not registered type: \(typeName)")
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [],
+                                                                    debugDescription: "Not registered type: \(typeName)"))
         }
         self.typeName = typeName
         self.value = try closure(container) as! Codable


### PR DESCRIPTION
replace fatal error with Decoding Error for unregistered types, because it can be an issue for JSON from serverside